### PR TITLE
Adding extra validation for HTMLAnchorElement on Server Side Rendering

### DIFF
--- a/packages/core/src/Parser.ts
+++ b/packages/core/src/Parser.ts
@@ -348,7 +348,7 @@ export default class Parser {
    */
   isSafe(node: HTMLElement): boolean {
     // URLs should only support HTTP and email
-    if (node instanceof HTMLAnchorElement) {
+    if (typeof HTMLAnchorElement !== 'undefined' && node instanceof HTMLAnchorElement) {
       const href = node.getAttribute('href');
 
       // Fragment protocols start with about:


### PR DESCRIPTION
While doing SSR, Node won't recognize `HTMLAnchorElement` to exist as a global variable.
So adding an extra validation to check if it's defined