### PR TITLE
Fix undefined match results in "undefined" string

### DIFF
--- a/packages/core/src/Parser.ts
+++ b/packages/core/src/Parser.ts
@@ -164,7 +164,7 @@ export default class Parser {
       let tokenizedString = '';
 
       while (matchedString && (parts = matcher.match(matchedString))) {
-        const { index, length, match, valid, ...partProps } = parts;
+        const { index, length, match = '', valid, ...partProps } = parts;
         const tokenName = matcher.propName + elementIndex;
 
         // Piece together a new string with interpolated tokens


### PR DESCRIPTION
This should fix a bug that when you have a matcher which should show an empty string with some styles it results in showing an `undefined` string.

Before:
```
{{{matcher0}}}undefined{{{/matcher0}}}
```
After:
```
{{{matcher0}}}{{{/matcher0}}}
```

### Example:
```
>Hello
>
>World
```

>Hello
>undefined
>World


>Hello
>
>World