### PR TITLE
Fix SSR support in Parser

### DIFF
--- a/packages/core/src/Parser.ts
+++ b/packages/core/src/Parser.ts
@@ -37,7 +37,7 @@ const OPEN_TOKEN = /{{{(\w+)\/?}}}/;
 
 function createDocument() {
   // Maybe SSR? Just do nothing instead of crashing!
-  if (typeof window === 'undefined' || typeof document === 'undefined') {
+  if (typeof document === 'undefined') {
     return undefined;
   }
 


### PR DESCRIPTION
The `interweave-ssr` only provides a `document` polyfill, so we shouldn't check for window.