### PR TITLE
new: MentionMatcher in autolink

### DIFF
--- a/packages/autolink/src/Mention.tsx
+++ b/packages/autolink/src/Mention.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Link } from './Link';
+import { MentionProps } from './types';
+
+export function Mention({ children, mention, mentionUrl = '{{mention}}', ...props }: MentionProps) {
+	// Determine the URL
+	let url = mentionUrl || '{{mention}}';
+
+	url = typeof url === 'function' ? url(mention) : url.replace('{{mention}}', mention);
+	return (
+		<Link {...props} href={url}>
+			{children}
+		</Link>
+	);
+}

--- a/packages/autolink/src/Mention.tsx
+++ b/packages/autolink/src/Mention.tsx
@@ -4,6 +4,7 @@ import { MentionProps } from './types';
 
 export function Mention({ children, mention, mentionUrl, ...props }: MentionProps) {
 	if (!mentionUrl) {
+		// eslint-disable-next-line react/jsx-no-useless-fragment
 		return <>{children}</>;
 	}
 

--- a/packages/autolink/src/Mention.tsx
+++ b/packages/autolink/src/Mention.tsx
@@ -2,11 +2,16 @@ import React from 'react';
 import { Link } from './Link';
 import { MentionProps } from './types';
 
-export function Mention({ children, mention, mentionUrl = '{{mention}}', ...props }: MentionProps) {
-	// Determine the URL
-	let url = mentionUrl || '{{mention}}';
+export function Mention({ children, mention, mentionUrl, ...props }: MentionProps) {
+	if (!mentionUrl) {
+		return null;
+	}
 
-	url = typeof url === 'function' ? url(mention) : url.replace('{{mention}}', mention);
+	const url =
+		typeof mentionUrl === 'function'
+			? mentionUrl(mention)
+			: mentionUrl.replace('{{mention}}', mention);
+
 	return (
 		<Link {...props} href={url}>
 			{children}

--- a/packages/autolink/src/Mention.tsx
+++ b/packages/autolink/src/Mention.tsx
@@ -4,7 +4,7 @@ import { MentionProps } from './types';
 
 export function Mention({ children, mention, mentionUrl, ...props }: MentionProps) {
 	if (!mentionUrl) {
-		return null;
+		return <>{children}</>;
 	}
 
 	const url =

--- a/packages/autolink/src/MentionMatcher.ts
+++ b/packages/autolink/src/MentionMatcher.ts
@@ -1,0 +1,26 @@
+import React from 'react';
+import { ChildrenNode, Matcher, Node } from 'interweave';
+import { Mention } from './Mention';
+import { MentionProps } from './types';
+
+const MENTION_PATTERN = new RegExp(`(^@[A-z0-9_-]+$)`);
+
+export class MentionMatcher extends Matcher<MentionProps> {
+	replaceWith(children: ChildrenNode, props: MentionProps): Node {
+		return React.createElement(Mention, props, children);
+	}
+
+	asTag(): string {
+		return 'a';
+	}
+
+	match(string: string) {
+		return this.doMatch(string, MENTION_PATTERN, this.handleMatches);
+	}
+
+	handleMatches(matches: string[]): { mention: string } {
+		return {
+			mention: matches[0],
+		};
+	}
+}

--- a/packages/autolink/src/MentionMatcher.ts
+++ b/packages/autolink/src/MentionMatcher.ts
@@ -3,7 +3,7 @@ import { ChildrenNode, Matcher, Node } from 'interweave';
 import { Mention } from './Mention';
 import { MentionProps } from './types';
 
-const MENTION_PATTERN = new RegExp(`(^@[A-z0-9_-]+$)`);
+const MENTION_PATTERN = /(^@[\dA-z-]+$)/;
 
 export class MentionMatcher extends Matcher<MentionProps> {
 	replaceWith(children: ChildrenNode, props: MentionProps): Node {

--- a/packages/autolink/src/index.ts
+++ b/packages/autolink/src/index.ts
@@ -10,6 +10,8 @@ export * from './Hashtag';
 export * from './HashtagMatcher';
 export * from './IpMatcher';
 export * from './Link';
+export * from './Mention';
+export * from './MentionMatcher';
 export * from './types';
 export * from './Url';
 export * from './UrlMatcher';

--- a/packages/autolink/src/types.ts
+++ b/packages/autolink/src/types.ts
@@ -44,3 +44,9 @@ export interface UrlMatcherOptions {
 	customTLDs?: string[];
 	validateTLD?: boolean;
 }
+
+export interface MentionProps extends Partial<LinkProps> {
+	children: ChildrenNode;
+	mention: string;
+	mentionUrl?: string | ((hashtag: string) => string);
+}

--- a/packages/autolink/src/types.ts
+++ b/packages/autolink/src/types.ts
@@ -48,5 +48,5 @@ export interface UrlMatcherOptions {
 export interface MentionProps extends Partial<LinkProps> {
 	children: ChildrenNode;
 	mention: string;
-	mentionUrl?: string | ((hashtag: string) => string);
+	mentionUrl: string | ((hashtag: string) => string);
 }

--- a/packages/autolink/tests/Mention.test.tsx
+++ b/packages/autolink/tests/Mention.test.tsx
@@ -49,7 +49,7 @@ describe('components/Mention', () => {
 
 	it('when mentionUrl not passed returns null', () => {
 		const result = render<MentionProps>(
-			<Mention newWindow mention="@interweave">
+			<Mention newWindow mention="@interweave" mentionUrl={undefined as never}>
 				@interweave
 			</Mention>,
 		);

--- a/packages/autolink/tests/Mention.test.tsx
+++ b/packages/autolink/tests/Mention.test.tsx
@@ -47,13 +47,13 @@ describe('components/Mention', () => {
 		expect(root.findOne(Link)).toHaveProp('onClick', func);
 	});
 
-	it('when mentionUrl not passed returns null', () => {
+	it('when mentionUrl not passed returns raw mention', () => {
 		const result = render<MentionProps>(
 			<Mention newWindow mention="@interweave" mentionUrl={undefined as never}>
 				@interweave
 			</Mention>,
 		);
 
-		expect(result.toTree()?.rendered).toBeNull();
+		expect(result.toTree()?.rendered).toBe('@interweave');
 	});
 });

--- a/packages/autolink/tests/Mention.test.tsx
+++ b/packages/autolink/tests/Mention.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render } from 'rut-dom';
+import { Link } from '../src/Link';
+import { Mention } from '../src/Mention';
+import { MentionProps } from '../src/types';
+
+describe('components/Mention', () => {
+	it('can define the URL', () => {
+		const { root } = render<MentionProps>(
+			<Mention mention="@interweave" mentionUrl="http://foo.com/{{mention}}">
+				@interweave
+			</Mention>,
+		);
+
+		expect(root).toContainNode('@interweave');
+		expect(root.findOne(Link)).toHaveProp('href', 'http://foo.com/@interweave');
+	});
+
+	it('can define the URL with a function', () => {
+		const { root } = render<MentionProps>(
+			<Mention
+				mention="@interweave"
+				mentionUrl={(mention) => `http://foo.com/${mention.toUpperCase()}`}
+			>
+				@interweave
+			</Mention>,
+		);
+
+		expect(root).toContainNode('@interweave');
+		expect(root.findOne(Link)).toHaveProp('href', 'http://foo.com/@INTERWEAVE');
+	});
+
+	it('can pass props to Link', () => {
+		const func = () => {};
+		const { root } = render<MentionProps>(
+			<Mention newWindow mention="@interweave" onClick={func}>
+				@interweave
+			</Mention>,
+		);
+
+		expect(root.findOne(Link)).toHaveProp('newWindow', true);
+		expect(root.findOne(Link)).toHaveProp('onClick', func);
+	});
+});

--- a/packages/autolink/tests/Mention.test.tsx
+++ b/packages/autolink/tests/Mention.test.tsx
@@ -33,12 +33,27 @@ describe('components/Mention', () => {
 	it('can pass props to Link', () => {
 		const func = () => {};
 		const { root } = render<MentionProps>(
-			<Mention newWindow mention="@interweave" onClick={func}>
+			<Mention
+				newWindow
+				mention="@interweave"
+				mentionUrl="http://foo.com/{{mention}}"
+				onClick={func}
+			>
 				@interweave
 			</Mention>,
 		);
 
 		expect(root.findOne(Link)).toHaveProp('newWindow', true);
 		expect(root.findOne(Link)).toHaveProp('onClick', func);
+	});
+
+	it('when mentionUrl not passed returns null', () => {
+		const result = render<MentionProps>(
+			<Mention newWindow mention="@interweave">
+				@interweave
+			</Mention>,
+		);
+
+		expect(result.toTree()?.rendered).toBeNull();
 	});
 });


### PR DESCRIPTION
resolves: #186 

PR to add `MentionMatcher` and `Mention` to be able to detect `@username` syntax.