### PR TITLE
docs: add props that are present in the types but not in docs

### DIFF
--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -103,10 +103,12 @@ _Markup & Interweave_
   be rendered.
 - `allowList` (`string[]`) - List of HTML tag names to allow and render. Defaults to the
   `ALLOWED_TAG_LIST` constant.
+- `attributes` (`Record<string, boolean | number | object | string>`) - HTML attributes to pass to the wrapping element.
 - `blockList` (`string[]`) - List of HTML tag names to disallow and not render. Overrides allow
   list.
 - `containerTagName` (`string`) - The container element to parse content in. Applies browser
   semantic rules and overrides `tagName`.
+- `className` (`string`) - CSS class name to pass to the wrapping element.
 - `content` (`string`) - The string to render and apply matchers and filters to. Supports HTML.
 - `disableLineBreaks` (`boolean`) - Disables automatic line break conversion.
 - `emptyContent` (`Node`) - React node to render if no content was rendered.
@@ -131,3 +133,4 @@ _Interweave only_
   must return a string.
 - `onAfterParse` (`func`) - Callback that fires after parsing. Is passed an array of
   strings/elements and must return an array.
+  


### PR DESCRIPTION
Following the conversation in https://github.com/milesj/interweave/issues/257

I didn't add `parsedContent` prop, as it seems to be for internal use only.