### PR TITLE
Add support for a .app URL

### DIFF
--- a/packages/autolink/src/constants.ts
+++ b/packages/autolink/src/constants.ts
@@ -211,6 +211,7 @@ export const TOP_LEVEL_TLDS = [
 	'travel',
 	'xxx',
 	// Misc
+	'app',
 	'arpa',
 	'test',
 	// Countries


### PR DESCRIPTION
Sample URL that is currently failing: https://randomnumberandcharactershere.ngrok-free.app/