### PR TITLE
Transform: node.tagName is case sensitive

### DIFF
--- a/website/docs/parser.md
+++ b/website/docs/parser.md
@@ -93,7 +93,7 @@ For example, to replace `a` elements with a custom element:
 import { Interweave, Node } from 'interweave';
 
 function transform(node: HTMLElement, children: Node[]): React.ReactNode {
-	if (node.tagName === 'a') {
+	if (node.tagName === 'A') {
 		return <Link href={node.getAttribute('href')}>{children}</Link>;
 	}
 }


### PR DESCRIPTION
It looked to me like all the `node.tagName`s were uppercase, even if the original HTML was in lowercase.

The `node.tagName === 'a'` in the example didn't work for me, but `node.tagName === 'A' or `node.tagName.toLowerCase() === 'a'` do.