### PR TITLE
Add support for React 19 (#272)

### DIFF
--- a/packages/autolink/package.json
+++ b/packages/autolink/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "peerDependencies": {
     "interweave": "^13.0.0",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "interweave-ssr": "^2.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,7 @@
     "escape-html": "^1.0.3"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "interweave-ssr": "^2.0.0",

--- a/packages/emoji-picker/package.json
+++ b/packages/emoji-picker/package.json
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "interweave-emoji": "^7.0.0",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "react": "^17.0.2"

--- a/packages/emoji/package.json
+++ b/packages/emoji/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "interweave": "^13.0.0",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "emojibase-test-utils": "^7.0.0",


### PR DESCRIPTION
Fixes #272

FWYW I've been using Interweave with React 19 for 3 weeks using [a package.json override](https://github.com/Athou/commafeed/pull/1657/files#diff-23ead321476055b2525d87ec8a5476aab958ad8054cb180d7892ba280ffe0815R82) and I haven't noticed any issue.